### PR TITLE
Remove standard identifiers from ISO citations

### DIFF
--- a/sources/guide-ccl-GD-MeP-3-en.adoc
+++ b/sources/guide-ccl-GD-MeP-3-en.adoc
@@ -382,59 +382,9 @@ The useful range of Si steps for the calibration of surface measuring instrument
 
 * [[[fu,23]]] Fu J, Tsai V, Köning R, Dixson R, and Vorburger T, "`Algorithms for calculating single-atom step heights`", Nanotechnology 10 (4) (1999) 428. https://aip.scitation.org/doi/abs/10.1063/1.56874[DOI: 10.1088/0957-4484/10/4/312]
 
-* [[[iso5436,ISO 5436-1:2000]]] ISO 5436-1:2000 Geometrical Product Specifications (GPS) -- Surface texture: Profile method; Measurement standards -- Part 1: Material measures
+* [[[iso5436,ISO 5436-1:2000]]], _Geometrical Product Specifications (GPS) -- Surface texture: Profile method; Measurement standards -- Part 1: Material measures_
 
-* [[[iso25178,ISO 25178-70:2014]]] ISO 25178-70:2014 Geometrical product specification (GPS) -- Surface texture: Areal -- Part 70: Material measures
+* [[[iso25178,ISO 25178-70:2014]]], _Geometrical product specification (GPS) -- Surface texture: Areal -- Part 70: Material measures_
 
 * [[[klapetek,26]]] Yacoot A, Klapetek P, Valtr M, Grolich P, Dongmo H, Lazzerini G M and Bridges A 2019 Design and performance of a test rig for evaluation of nanopositioning stages Meas. Sci. Technol. stem:[30035002] (10pp) https://doi.org/10.1088/1361-6501/aafd03[DOI: 10.1088/1361-6501/aafd03]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/sources/mep-metre-definition-en.adoc
+++ b/sources/mep-metre-definition-en.adoc
@@ -686,4 +686,4 @@ Further detailed information concerning the use of monoatomic steps as a seconda
 
 * [[[newell,1]]] Mohr P J, Newell D B, Taylor B N and Tiesinga E, "`Data and analysis for the CODATA 2017 special fundamental constants adjustment`", _Metrologia_ *55* (1) (2018) 125. DOI: 10.1088/1681-7575/aa99bc
 
-* [[[iso5436-1,(2)ISO 5436-1]]] ISO 5436-1, "`Geometrical Product Specifications (GPS) - Surface texture: Profile method; Measurement standards - Part 1: Material measures`", International Organization for Standardization, Geneva, Switzerland (2000). https://www.iso.org/standard/21978.html
+* [[[iso5436-1,ISO 5436-1]]], "`Geometrical Product Specifications (GPS) - Surface texture: Profile method; Measurement standards - Part 1: Material measures`", International Organization for Standardization, Geneva, Switzerland (2000). https://www.iso.org/standard/21978.html


### PR DESCRIPTION
*As requested in https://github.com/metanorma/metanorma-bipm/issues/74*

I've checked [bipm-si-brochure](https://github.com/metanorma/bipm-si-brochure) and [mn-samples-bipm](https://github.com/metanorma/mn-samples-bipm). Just few cases were found in the former.