### PR TITLE
Insert Metrologia references to the Brochure

### DIFF
--- a/sources/sections-a1-en/12-cipm-1967.adoc
+++ b/sources/sections-a1-en/12-cipm-1967.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Decimal multiples and submultiples of the unit of mass* (<<PV35_2>> and _Metrologia_, 1968, *4*, 45) (((mass)))
+*Decimal multiples and submultiples of the unit of mass* (<<PV35_2>> and <<Met_4_1_41,_Metrologia_, 1968, *4*, 45>>) (((mass)))
 
 [[cipm1967r2r2]]
 ==== Recommendation 2

--- a/sources/sections-a1-en/13-13th-cgpm.adoc
+++ b/sources/sections-a1-en/13-13th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*SI unit of time (second)* (<<CR1967-1>> and _Metrologia_, 1968, *4*, 43) (((second (stem:["unitsml(s)"]))))
+*SI unit of time (second)* (<<CR1967-1>> and <<Met_4_1_41,_Metrologia_, 1968, *4*, 43>>) (((second (stem:["unitsml(s)"]))))
 
 [[cgpm13th1967r1r1]]
 ==== Resolution 1
@@ -37,7 +37,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*SI unit of thermodynamic temperature (kelvin)* (<<CR1967-3>> and _Metrologia_, 1968, *4*, 43)(((International Temperature Scale of 1990 (ITS-90))))(((kelvin (stem:["unitsml(K)"]))))(((thermodynamic temperature)))
+*SI unit of thermodynamic temperature (kelvin)* (<<CR1967-3>> and <<Met_4_1_41,_Metrologia_, 1968, *4*, 43>>)(((International Temperature Scale of 1990 (ITS-90))))(((kelvin (stem:["unitsml(K)"]))))(((thermodynamic temperature)))
 
 NOTE: At its 1980 meeting, the CIPM approved the report of the 7th meeting of the CCU, which requested that the use of the symbols "stem:["unitsml(degK)"]" and "stem:["deg"]" no longer be permitted.
 
@@ -70,7 +70,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Definition of the SI unit of thermodynamic temperature (kelvin)* (<<CR1967-4>> and _Metrologia_, 1968, *4*, 43)(((kelvin (stem:["unitsml(K)"]))))(((thermodynamic temperature)))
+*Definition of the SI unit of thermodynamic temperature (kelvin)* (<<CR1967-4>> and <<Met_4_1_41,_Metrologia_, 1968, *4*, 43>>)(((kelvin (stem:["unitsml(K)"]))))(((thermodynamic temperature)))
 
 NOTE: See Recommendation 5 (<<cipm1989temp,CI-1989>>) of the CIPM on the International Temperature Scale of 1990.
 
@@ -94,7 +94,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*SI unit of luminous intensity (candela)* (<<CR1967-5>> and _Metrologia_, 1968, *4*, 43-44)(((Luminous intensity)))
+*SI unit of luminous intensity (candela)* (<<CR1967-5>> and <<Met_1968_4_43,_Metrologia_, 1968, *4*, 43-44>>)(((Luminous intensity)))
 
 NOTE: This definition was abrogated by the 16th CGPM in 1979 (<<cgpm16th1979r3r3,Resolution 3>>).
 
@@ -123,7 +123,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*SI derived units* (<<CR1968-6>> and _Metrologia_, 1968, *4*, 44)index:see["unit, derived",derived unit(s)](((derived unit(s))))((("multiples, prefixes for")))(((prefixes)))
+*SI derived units* (<<CR1968-6>> and <<Met_4_1_41,_Metrologia_, 1968, *4*, 44>>)index:see["unit, derived",derived unit(s)](((derived unit(s))))((("multiples, prefixes for")))(((prefixes)))
 
 NOTE: The unit of activity was given a special name and symbol by the 15th CGPM in 1975 (<<cgpm15th1975r8_9,Resolution 8>>).
 
@@ -156,7 +156,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Abrogation of earlier decisions (micron and new candle)* (<<CR1968-7>> and _Metrologia_, 1968, *4*, 44) ((("submultiples, prefixes for")))(((candela (stem:["unitsml(cd)"]),new candle)))
+*Abrogation of earlier decisions (micron and new candle)* (<<CR1968-7>> and <<Met_4_1_41,_Metrologia_, 1968, *4*, 44>>) ((("submultiples, prefixes for")))(((candela (stem:["unitsml(cd)"]),new candle)))
 
 [[cgpm13th1967r7r7]]
 ==== Resolution 7

--- a/sources/sections-a1-en/14-cipm-1969.adoc
+++ b/sources/sections-a1-en/14-cipm-1969.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Système International d'Unités, Rules for application of Resolution 12 of the 11th CGPM (1960)* (<<PV37>> and _Metrologia_, 1970, *6*, 66)
+*Système International d'Unités, Rules for application of Resolution 12 of the 11th CGPM (1960)* (<<PV37>> and <<Met_6_2_65,_Metrologia_, 1970, *6*, 66>>)
 
 NOTE: The 20th CGPM in 1995 decided to abrogate the class of ((supplementary units)) in the SI (<<cgpm20th1995r8r8,Resolution 8>>).
 

--- a/sources/sections-a1-en/15-ccds-1970.adoc
+++ b/sources/sections-a1-en/15-ccds-1970.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Definition of TAI* (<<PV38>> and _Metrologia_, 1971, *7*, 43)
+*Definition of TAI* (<<PV38>> and <<Met_7_1_43,_Metrologia_, 1971, *7*, 43>>)
 
 [NOTE]
 ====
@@ -25,7 +25,7 @@ ____
 International Atomic Time (TAI) is the time reference coordinate established by the Bureau International de l'Heure on the basis of the readings of atomic clocks operating in various establishments in accordance with the definition of the second, the unit of time of the International System of Units.
 ____
 
-In 1980, the definition of TAI was completed as follows (declaration of the CCDS, _BIPM Com. Cons. Déf. Seconde_, 1980, *9*, S 15 and _Metrologia_, 1981, *17*, 70):
+In 1980, the definition of TAI was completed as follows (declaration of the CCDS, _BIPM Com. Cons. Déf. Seconde_, 1980, *9*, S 15 and <<Met_17_2_69,_Metrologia_, 1981, *17*, 70>>):
 
 ____
 TAI is a coordinate time scale defined in a geocentric reference frame with the SI second as realized on the rotating geoid as the scale unit.

--- a/sources/sections-a1-en/16-14th-cgpm.adoc
+++ b/sources/sections-a1-en/16-14th-cgpm.adoc
@@ -18,7 +18,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*International Atomic Time, function of CIPM* (<<CR1971-1>> and _Metrologia_, 1972, *8*, 35) (((International Atomic Time (TAI))))
+*International Atomic Time, function of CIPM* (<<CR1971-1>> and <<Met_8_1_32,_Metrologia_, 1972, *8*, 35>>) (((International Atomic Time (TAI))))
 
 [[cgpm14th1971r1r1]]
 ==== Resolution 1
@@ -49,7 +49,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*SI unit of amount of substance (mole)* (<<CR1971-3>> and _Metrologia_, 1972, *8*, 36)(((mole (stem:["unitsml(mol)"]))))
+*SI unit of amount of substance (mole)* (<<CR1971-3>> and <<Met_8_1_32_Metrologia_, 1972, *8*, 36>>)(((mole (stem:["unitsml(mol)"]))))
 
 NOTE: At its 1980 meeting, the CIPM approved the report of the 7th meeting of the CCU (1980) specifying that, in this definition, it is understood that unbound atoms of ((carbon 12)), at rest and in their ground state, are referred to.
 

--- a/sources/sections-a1-en/17-15th-cgpm.adoc
+++ b/sources/sections-a1-en/17-15th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Recommended value for the speed of light* (<<CR1975-2>> and _Metrologia_, 1975, *11*, 179-180)
+*Recommended value for the speed of light* (<<CR1975-2>> and <<Met_11_4_179,_Metrologia_, 1975, *11*, 179-180>>)
 
 [[cgpm15th1975r2r2]]
 ==== Resolution 2
@@ -27,7 +27,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Coordinated Universal Time (UTC)* (<<CR1975-5>> and _Metrologia_, 1975, *11*, 180) index:see[UTC,Coordinated Universal Time] (((Coordinated Universal Time (UTC))))
+*Coordinated Universal Time (UTC)* (<<CR1975-5>> and <<Met_11_4_179,_Metrologia_, 1975, *11*, 180>>) index:see[UTC,Coordinated Universal Time] (((Coordinated Universal Time (UTC))))
 
 [[cgpm15th1975r5r5]]
 ==== Resolution 5
@@ -47,7 +47,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*SI units for ionizing radiation (becquerel and gray)* (<<CR1975-8>> and _Metrologia_, 1975, *11*, 180)(((becquerel (stem:["unitsml(Bq)"]))))index-range:gray[(((gray (stem:["unitsml(Gy)"]))))]index-range:ionizing_radiation[(((ionizing radiation)))]
+*SI units for ionizing radiation (becquerel and gray)* (<<CR1975-8>> and <<Met_11_4_179,_Metrologia_, 1975, *11*, 180>>)(((becquerel (stem:["unitsml(Bq)"]))))index-range:gray[(((gray (stem:["unitsml(Gy)"]))))]index-range:ionizing_radiation[(((ionizing radiation)))]
 
 NOTE: At its 1976 meeting, the CIPM approved the report of the 5th meeting of the CCU (1976), specifying that, following the advice of the ICRU, the gray may also be used to express specific energy imparted, kerma and ((absorbed dose)) index.
 
@@ -81,7 +81,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*SI prefixes peta and exa* (<<CR1975-10>> and _Metrologia_, 1975, *11*, 180-181)((("multiples, prefixes for")))(((prefixes)))(((SI prefixes)))
+*SI prefixes peta and exa* (<<CR1975-10>> and <<Met_11_4_179,_Metrologia_, 1975, *11*, 180-181>>)((("multiples, prefixes for")))(((prefixes)))(((SI prefixes)))
 
 NOTE: New prefixes were added by the 19th CGPM in 1991 (<<cgpm19th1991r4r4,Resolution 4>>).
 

--- a/sources/sections-a1-en/18-16th-cgpm.adoc
+++ b/sources/sections-a1-en/18-16th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*SI unit of luminous intensity (candela)* (<<CR1979-3>> and _Metrologia_, 1980, *16*, 56)(((lumen (stem:["unitsml(lm)"]))))(((luminous intensity)))(((candela (stem:["unitsml(cd)"]))))
+*SI unit of luminous intensity (candela)* (<<CR1979-3>> and <<Met_16_1_55,_Metrologia_, 1980, *16*, 56>>)(((lumen (stem:["unitsml(lm)"]))))(((luminous intensity)))(((candela (stem:["unitsml(cd)"]))))
 
 NOTE: The wording of the definition of the candela was modified by the 26th CGPM in 2018 (<<cgpm26th2018r1r1,Resolution 1>>).
 
@@ -42,7 +42,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Special name for the SI unit of dose equivalent (sievert)* (<<CR1979-5>> and _Metrologia_, 1980, *16*, 56)index:see[dose equivalent,sievert](((sievert (stem:["unitsml(Sv)"]))))
+*Special name for the SI unit of dose equivalent (sievert)* (<<CR1979-5>> and <<Met_16_1_55,_Metrologia_, 1980, *16*, 56>>)index:see[dose equivalent,sievert](((sievert (stem:["unitsml(Sv)"]))))
 
 NOTE: The CIPM, in 1984, decided to accompany this Resolution with an explanation (<<cipm1984r1r1,Recommendation 1>>).
 
@@ -67,7 +67,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Symbols for the litre* (<<CR1979-6>> and _Metrologia_, 1980, *16*, 56-57) (((litre (stem:["unitsml(L)"] or stem:["unitsml(l)"]))))
+*Symbols for the litre* (<<CR1979-6>> and <<Met_16_1_55,_Metrologia_, 1980, *16*, 56-57>>) (((litre (stem:["unitsml(L)"] or stem:["unitsml(l)"]))))
 
 [[cgpm16th1979r6r6]]
 ==== Resolution 6

--- a/sources/sections-a1-en/19-cipm-1980.adoc
+++ b/sources/sections-a1-en/19-cipm-1980.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*SI supplementary units (radian and steradian)* (<<PV48>> and _Metrologia_, 1981, *17*, 72)
+*SI supplementary units (radian and steradian)* (<<PV48>> and <<Met_17_2_69,_Metrologia_, 1981, *17*, 72>>)
 
 NOTE: The class of SI supplementary units was abrogated by decision of the 20th CGPM in 1995 (<<cgpm20th1995r8r8,Resolution 8>>).
 

--- a/sources/sections-a1-en/20-17th-cgpm.adoc
+++ b/sources/sections-a1-en/20-17th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Definition of the metre* (<<CR1983-1>> and _Metrologia_, 1984, *20*, 25)(((metre (stem:["unitsml(m)"]))))
+*Definition of the metre* (<<CR1983-1>> and <<Met_20_1_25,_Metrologia_, 1984, *20*, 25>>)(((metre (stem:["unitsml(m)"]))))
 
 NOTE: The wording of the definition of the metre was modified by the 26th CGPM in 2018 (<<cgpm26th2018r1r1,Resolution 1>>).
 
@@ -41,7 +41,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*On the realization of the definition of the metre* (<<CR1983-2>> and _Metrologia_, 1984, *20*, 25-26)(((metre (stem:["unitsml(m)"]))))
+*On the realization of the definition of the metre* (<<CR1983-2>> and <<Met_20_1_25,_Metrologia_, 1984, *20*, 25-26>>)(((metre (stem:["unitsml(m)"]))))
 
 NOTE: See Recommendation 1 (CI-2002) of the CIPM on the revision of the practical realization of the definition of the metre, p. 181.
 

--- a/sources/sections-a1-en/21-cipm-1984.adoc
+++ b/sources/sections-a1-en/21-cipm-1984.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Concerning the sievert* (<<PV52>> and _Metrologia_, 1985, *21*, 90)(((sievert (stem:["unitsml(Sv)"]))))
+*Concerning the sievert* (<<PV52>> and <<Met_21_2_89,_Metrologia_, 1985, *21*, 90>>)(((sievert (stem:["unitsml(Sv)"]))))
 
 NOTE: The CIPM, in 2002, decided to change the explanation of the quantity dose equivalent in the SI Brochure (<<cipm2002r2r2,Recommendation 2>>).
 

--- a/sources/sections-a1-en/22-18th-cgpm.adoc
+++ b/sources/sections-a1-en/22-18th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Forthcoming adjustment to the representations of the volt and of the ohm* (<<CR1987-6>> and _Metrologia_, 1988, *25*, 115) (((ohm (stem:["unitsml(Ohm)"])))) index-range:volt_v[(((volt (stem:["unitsml(V)"]))))]
+*Forthcoming adjustment to the representations of the volt and of the ohm* (<<CR1987-6>> and <<Met_25_2_113,_Metrologia_, 1988, *25*, 115>>) (((ohm (stem:["unitsml(Ohm)"])))) index-range:volt_v[(((volt (stem:["unitsml(V)"]))))]
 
 [[cgpm18th1987r6r6]]
 ==== Resolution 6

--- a/sources/sections-a1-en/23-cipm-1988.adoc
+++ b/sources/sections-a1-en/23-cipm-1988.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Representation of the volt by means of the Josephson effect* (<<PV56_1>> and _Metrologia_, 1989, *26*, 69)(((Josephson effect)))(((volt (stem:["unitsml(V)"]))))
+*Representation of the volt by means of the Josephson effect* (<<PV56_1>> and <<Met_26_1_69,_Metrologia_, 1989, *26*, 69>>)(((Josephson effect)))(((volt (stem:["unitsml(V)"]))))
 
 NOTE: The 26th CGPM in 2018 (<<cgpm26th2018r1r1,Resolution 1>>) abrogated the adoption of a conventional value for stem:[ii(K)_"J"].
 
@@ -43,7 +43,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Representation of the ohm by means of the quantum Hall effect* (<<PV56_2>> and _Metrologia_, 1989, *26*,70)index-range:hall_effect[(((Hall effect (incl. quantum Hall effect))))]index-range:ohm_omega[(((ohm (stem:["unitsml(Ohm)"]))))](((quantum Hall effect)))(((von Klitzing constant (stem:[R_K,R_{k-90}]))))
+*Representation of the ohm by means of the quantum Hall effect* (<<PV56_2>> and <<Met_26_1_69,_Metrologia_, 1989, *26*, 70>>)index-range:hall_effect[(((Hall effect (incl. quantum Hall effect))))]index-range:ohm_omega[(((ohm (stem:["unitsml(Ohm)"]))))](((quantum Hall effect)))(((von Klitzing constant (stem:[R_K,R_{k-90}]))))
 
 NOTE: At its 89th meeting in 2000, the CIPM approved the declaration of the 22nd meeting of the CCEM on the use of the value of the von Klitzing constant.
 

--- a/sources/sections-a1-en/24-cipm-1989.adoc
+++ b/sources/sections-a1-en/24-cipm-1989.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*The International Temperature Scale of 1990* (<<PV57_5>> and _Metrologia_, 1990, *27*, 13)(((International Temperature Scale of 1990 (ITS-90))))
+*The International Temperature Scale of 1990* (<<PV57_5>> and <<Met_27_1_11,_Metrologia_, 1990, *27*, 13>>)(((International Temperature Scale of 1990 (ITS-90))))
 
 NOTE: The kelvin was redefined by the 26th CGPM in 2018 (<<cgpm26th2018r1r1,Resolution 1>>). (((kelvin (stem:["unitsml(K)"]))))
 

--- a/sources/sections-a1-en/25-19th-cgpm.adoc
+++ b/sources/sections-a1-en/25-19th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*SI prefixes zetta, zepto, yotta and yocto* (<<CR1991-4>> and _Metrologia_, 1992, *29*, 3) ((("multiples, prefixes for"))) ((("submultiples, prefixes for"))) (((prefixes))) (((SI prefixes)))
+*SI prefixes zetta, zepto, yotta and yocto* (<<CR1991-4>> and <<Met_29_1_1,_Metrologia_, 1992, *29*, 3>>) ((("multiples, prefixes for"))) ((("submultiples, prefixes for"))) (((prefixes))) (((SI prefixes)))
 
 [[cgpm19th1991r4r4]]
 ==== Resolution 4

--- a/sources/sections-a1-en/26-20th-cgpm.adoc
+++ b/sources/sections-a1-en/26-20th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Elimination of the class of supplementary units in the SI* (<<CR1995-8>> and _Metrologia_, 1996, *33*, 83) (((supplementary units)))
+*Elimination of the class of supplementary units in the SI* (<<CR1995-8>> and <<Met_33_1_81,_Metrologia_, 1996, *33*, 83>>) (((supplementary units)))
 
 [[cgpm20th1995r8r8]]
 ==== Resolution 8

--- a/sources/sections-a1-en/27-21st-cgpm.adoc
+++ b/sources/sections-a1-en/27-21st-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*The definition of the kilogram* (<<CR1999-7>> and _Metrologia_, 2000, *37*, 94)
+*The definition of the kilogram* (<<CR1999-7>> and <<Met_37_1_87,_Metrologia_, 2000, *37*, 94>>)
 
 [[cgpm21st1999r7r7]]
 ==== Resolution 7
@@ -36,7 +36,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Special name for the SI derived unit mole per second, the katal, for the expression of catalytic activity* (<<CR1999-12>> and _Metrologia_, 2000, *37*, 95) (((katal (stem:["unitsml(kat)"])))) (((mole (stem:["unitsml(mol)"])))) (((non-SI units))) (((second (stem:["unitsml(s)"]))))
+*Special name for the SI derived unit mole per second, the katal, for the expression of catalytic activity* (<<CR1999-12>> and <<Met_37_1_87,_Metrologia_, 2000, *37*, 95>>) (((katal (stem:["unitsml(kat)"])))) (((mole (stem:["unitsml(mol)"])))) (((non-SI units))) (((second (stem:["unitsml(s)"]))))
 
 [[cgpm21st1999r12r12]]
 ==== Resolution 12

--- a/sources/sections-a1-en/29-cipm-2002.adoc
+++ b/sources/sections-a1-en/29-cipm-2002.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Revision of the practical realization of the definition of the metre* (<<PV70_1>> and _Metrologia_, *40*, 103-133) (((metre (stem:["unitsml(m)"]))))
+*Revision of the practical realization of the definition of the metre* (<<PV70_1>> and <<Met_40_2_103,_Metrologia_, *40*, 103-133>>) (((metre (stem:["unitsml(m)"]))))
 
 [[cipm2002r1r1]]
 ==== Recommendation 1
@@ -35,7 +35,7 @@ The International Committee for Weights and Measures,
 ... [[cipm2002-c]]by means of one of the radiations from the list below, whose stated wavelength in vacuum or whose stated frequency can be used with the uncertainty shown, provided that the given specifications and accepted good practice are followed;
 --
 ** that in all cases any necessary corrections be applied to take account of actual conditions such as diffraction, gravitation or imperfection in the vacuum; (((general relativity)))
-** that in the context of general relativity, the metre is considered a unit of proper length. Its definition, therefore, applies only within a spatial extent sufficiently small that the effects of the non-uniformity of the gravitational field can be ignored (note that, at the surface of the Earth, this effect in the vertical direction is about 1 part in stem:[10^(16) text( per metre)]). In this case, the effects to be taken into account are those of special relativity only. The local methods for the realization of the metre recommended in <<cipm2002-b>> and <<cipm2002-c>> provide the proper metre but not necessarily that given in <<cipm2002-a>>. Method <<cipm2002-a>> should therefore be restricted to lengths stem:[l] which are sufficiently short for the effects predicted by general relativity to be negligible with respect to the uncertainties of realization. For advice on the interpretation of measurements in which this is not the case, see the report of the Consultative Committee for Time and Frequency (CCTF) Working Group on the Application of General Relativity to Metrology (Application of general relativity to metrology, _Metrologia_, 1997, *34*, 261-290);
+** that in the context of general relativity, the metre is considered a unit of proper length. Its definition, therefore, applies only within a spatial extent sufficiently small that the effects of the non-uniformity of the gravitational field can be ignored (note that, at the surface of the Earth, this effect in the vertical direction is about 1 part in stem:[10^(16) text( per metre)]). In this case, the effects to be taken into account are those of special relativity only. The local methods for the realization of the metre recommended in <<cipm2002-b>> and <<cipm2002-c>> provide the proper metre but not necessarily that given in <<cipm2002-a>>. Method <<cipm2002-a>> should therefore be restricted to lengths stem:[l] which are sufficiently short for the effects predicted by general relativity to be negligible with respect to the uncertainties of realization. For advice on the interpretation of measurements in which this is not the case, see the report of the Consultative Committee for Time and Frequency (CCTF) Working Group on the Application of General Relativity to Metrology (Application of general relativity to metrology, <<Met_34_3_261,_Metrologia_, 1997, *34*, 261-290>>);
 
 * that the CIPM had already recommended a list of radiations for this purpose;
 
@@ -58,7 +58,7 @@ The International Committee for Weights and Measures,
 
 *recommends*
 
-* that the list of recommended radiations given by the CIPM in 1997 (Recommendation 1 (CI-1997)) be replaced by the list of radiations given below footnote:[The list of recommended radiations, Recommendation 1 (CI-2002), is given in <<PV70_1>> and _Metrologia_, 2003, *40*, 104-115.], including
+* that the list of recommended radiations given by the CIPM in 1997 (Recommendation 1 (CI-1997)) be replaced by the list of radiations given below footnote:[The list of recommended radiations, Recommendation 1 (CI-2002), is given in <<PV70_1>> and <<Met_40_2_103,_Metrologia_, 2003, *40*, 104-115>>.], including
 ** updated frequency values for cold stem:["Ca"] atom, stem:["H"] atom and the trapped stem:["Sr"^+] ion,
 ** frequency values for new cold ion species including trapped stem:["Hg"^\+] ion, trapped stem:["In"^+] ion and trapped stem:["Yb"^+] ion,
 ** updated frequency values for stem:["Rb"]-stabilized lasers, stem:["I"_2]-stabilized Nd:YAG and stem:["He-Ne"] lasers, stem:["CH"_4]-stabilized stem:["He-Ne"] lasers and stem:["OsO"_4]-stabilized stem:["CO"_2] lasers at stem:[10 " "mu "m"],

--- a/sources/sections-a1-en/30-cipm-2003.adoc
+++ b/sources/sections-a1-en/30-cipm-2003.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Revision of the Mise en Pratique list of recommended radiations* (<<PV71_1>> and _Metrologia_, 2004, *41*, 99-100)
+*Revision of the Mise en Pratique list of recommended radiations* (<<PV71_1>> and <<Met_41_1_99,_Metrologia_, 2004, *41*, 99-100>>)
 
 [[cipm2003r1r1]]
 ==== Recommendation 1

--- a/sources/sections-a1-en/31-22nd-cgpm.adoc
+++ b/sources/sections-a1-en/31-22nd-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Symbol for the ((decimal marker))* (<<CR2003-10>> and _Metrologia_, 2004, *41*, 104)
+*Symbol for the ((decimal marker))* (<<CR2003-10>> and <<Met_41_1_99,_Metrologia_, 2004, *41*, 104>>)
 
 [[cgpm22nd2003r10r10]]
 ==== Resolution 10

--- a/sources/sections-a1-en/32-cipm-2005.adoc
+++ b/sources/sections-a1-en/32-cipm-2005.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Clarification of the definition of the kelvin, unit of thermodynamic temperature* (<<PV73_2>> and _Metrologia_, 2006, *43*, 177-178)
+*Clarification of the definition of the kelvin, unit of thermodynamic temperature* (<<PV73_2>> and <<Met_43_1_175,_Metrologia_, 2006, *43*, 177-178>>)
 
 NOTE: The kelvin was redefined by the 26th CGPM in 2018 (<<cgpm26th2018r1r1,Resolution 1>>).
 
@@ -53,7 +53,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Revision of the _Mise en pratique_ list of recommended radiations* (<<PV73_3>> and _Metrologia_, 2006, *43*, 178)
+*Revision of the _Mise en pratique_ list of recommended radiations* (<<PV73_3>> and <<Met_43_1_175,_Metrologia_, 2006, *43*, 178>>)
 
 [[cipm2005r3r3]]
 ==== Recommendation 3

--- a/sources/sections-a1-en/33-cipm-2006.adoc
+++ b/sources/sections-a1-en/33-cipm-2006.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Concerning secondary representations of the second* (<<PV74>> and _Metrologia_, 2007, *44*, 97) (((second (stem:["unitsml(s)"]))))
+*Concerning secondary representations of the second* (<<PV74>> and <<Met_44_1_97,_Metrologia_, 2007, *44*, 97>>) (((second (stem:["unitsml(s)"]))))
 
 [[cipm2006r1r1]]
 ==== Recommendation 1

--- a/sources/sections-a1-en/39-25th-cgpm.adoc
+++ b/sources/sections-a1-en/39-25th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*On the future revision of the International System of Units, the SI* (<<CR2014-1>> and _Metrologia_, 2015, *52*, 155)
+*On the future revision of the International System of Units, the SI* (<<CR2014-1>> and <<Met_52_1_155,_Metrologia_, 2015, *52*, 155>>)
 
 NOTE: The 26th CGPM in 2018 (<<cgpm26th2018r1r1,Resolution 1>>) finally approved the revision of the SI.
 

--- a/sources/sections-a1-en/42-26th-cgpm.adoc
+++ b/sources/sections-a1-en/42-26th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*On the revision of the International System of Units, the SI* (CR, in press and _Metrologia_, 2019, *56*, 022001)
+*On the revision of the International System of Units, the SI* (CR, in press and <<Met_56_2_022001,_Metrologia_, 2019, *56*, 022001>>)
 
 [[cgpm26th2018r1r1]]
 ==== Resolution 1

--- a/sources/sections-a1-fr/12-cipm-1967.adoc
+++ b/sources/sections-a1-fr/12-cipm-1967.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Multiples et sous-multiples décimaux de l’unité de masse* (<<PV35_2>> et _Metrologia_, 1968, *4*, 45)
+*Multiples et sous-multiples décimaux de l’unité de masse* (<<PV35_2>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 45>>)
 
 [[cipm1967r2r2]]
 ==== Recommandation 2

--- a/sources/sections-a1-fr/13-13th-cgpm.adoc
+++ b/sources/sections-a1-fr/13-13th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Unité SI de temps (seconde)* (<<CR1967-1>> et _Metrologia_, 1968, *4*, 43) (((seconde)))
+*Unité SI de temps (seconde)* (<<CR1967-1>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 43>>) (((seconde)))
 
 [[cgpm13e1968r1r1]]
 ==== Résolution 1
@@ -54,7 +54,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Unité SI de température thermodynamique (kelvin)* (<<CR1967-3>> et _Metrologia_, 1968, *4*, 43)(((kelvin (stem:["unitsml(K)"]))))
+*Unité SI de température thermodynamique (kelvin)* (<<CR1967-3>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 43>>)(((kelvin (stem:["unitsml(K)"]))))
 
 NOTE: À sa session de 1980, le Comité international a
 approuvé le rapport de la 7^e^ session du CCU
@@ -99,7 +99,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Définition de l’unité SI de température thermodynamique (kelvin)* (<<CR1967-4>> et _Metrologia_, 1968, *4*, 43)(((kelvin (stem:["unitsml(K)"]))))
+*Définition de l’unité SI de température thermodynamique (kelvin)* (<<CR1967-4>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 43>>)(((kelvin (stem:["unitsml(K)"]))))
 
 NOTE: Voir la Recommandation 5 (<<cipm1989r5r5,CI-1989>>) du CIPM relative à l’Échelle
 internationale de température de 1990.
@@ -130,7 +130,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Unité SI d’intensité lumineuse (candela)* (<<CR1967-5>> et _Metrologia_, 1968, *4*, 43-44)(((candela (stem:["unitsml(cd)"]))))
+*Unité SI d’intensité lumineuse (candela)* (<<CR1967-5>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 43-44>>)(((candela (stem:["unitsml(cd)"]))))
 
 NOTE: Définition abrogée en 1979 par la 16^e^ CGPM (<<cgpm16e1979r3r3,Résolution 3>>).
 
@@ -165,7 +165,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Unités SI dérivées* (<<CR1968-6>> et _Metrologia_, 1968, *4*, 44)
+*Unités SI dérivées* (<<CR1968-6>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 44>>)
 
 NOTE: L’unité d’activité a reçu un nom spécial et un
 symbole particulier lors de la 15^e^ CGPM en 1975 (<<cgpm15e1975r8_9r8_9,Résolution 8>>).
@@ -198,7 +198,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Abrogation de décisions antérieures (micron et bougie nouvelle)(((bougie nouvelle)))* (<<CR1968-7>> et _Metrologia_, 1968, *4*, 44)
+*Abrogation de décisions antérieures (micron et bougie nouvelle)(((bougie nouvelle)))* (<<CR1968-7>> et <<Met_4_1_41,_Metrologia_, 1968, *4*, 44>>)
 
 [[cgpm13e1968r7r7]]
 ==== Résolution 7

--- a/sources/sections-a1-fr/14-cipm-1969.adoc
+++ b/sources/sections-a1-fr/14-cipm-1969.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Système international d’unités, modalités d’application de la Résolution 12 de la 11^e^ CGPM (1960)* (<<PV37>> et _Metrologia_, 1970, *6*, 66)
+*Système international d’unités, modalités d’application de la Résolution 12 de la 11^e^ CGPM (1960)* (<<PV37>> et <<Met_6_2_65,_Metrologia_, 1970, *6*, 66>>)
 
 NOTE: La 20^e^ CGPM a décidé d’abroger en 1995 (<<cgpm20e1995r8r8,Résolution 8>>) la classe des unités supplémentaires dans le SI.
 

--- a/sources/sections-a1-fr/15-ccds-1970.adoc
+++ b/sources/sections-a1-fr/15-ccds-1970.adoc
@@ -23,7 +23,7 @@ constante.{nbsp}»
 === {blank}
 
 [.variant-title,type=quoted]
-*Définition du TAI* (<<PV38>> et _Metrologia_, 1971, *7*, 43)
+*Définition du TAI* (<<PV38>> et <<Met_7_1_43,_Metrologia_, 1971, *7*, 43>>)
 
 [[ccds-tai-definition_s2]]
 ==== Recommandation S 2
@@ -36,7 +36,7 @@ international d’unités.
 ____
 
 En 1980, la définition du TAI a été complétée comme suit (déclaration du CCDS, _BIPM Com.
-cons. déf. seconde_, 1980, 9, S 15 et _Metrologia_, 1981, *17*, 70){nbsp}:
+cons. déf. seconde_, 1980, 9, S 15 et <<Met_17_2_69,_Metrologia_, 1981, *17*, 70>>){nbsp}:
 
 ____
 Le TAI est une échelle de temps-coordonnée définie dans un repère de référence géocentrique

--- a/sources/sections-a1-fr/16-14th-cgpm.adoc
+++ b/sources/sections-a1-fr/16-14th-cgpm.adoc
@@ -20,7 +20,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Temps atomique international{nbsp}; rôle du CIPM* (<<CR1971-1>> et _Metrologia_, 1972, *8*, 35) index-range:temps_tai[(((temps,atomique international (TAI))))]
+*Temps atomique international{nbsp}; rôle du CIPM* (<<CR1971-1>> et <<Met_8_1_32,_Metrologia_, 1972, *8*, 35>>) index-range:temps_tai[(((temps,atomique international (TAI))))]
 
 [[cgpm14e1971r1r1]]
 ==== Résolution 1
@@ -66,7 +66,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Unité SI de quantité de matière (mole)* (<<CR1971-3>> et _Metrologia_, 1972, *8*, 36)(((mole (stem:["unitsml(mol)"]))))(((quantité de matière)))
+*Unité SI de quantité de matière (mole)* (<<CR1971-3>> et <<Met_8_1_32,_Metrologia_, 1972, *8*, 36>>)(((mole (stem:["unitsml(mol)"]))))(((quantité de matière)))
 
 NOTE: À sa session de 1980, le CIPM a approuvé le rapport de la 7^e^ session du
 CCU (1980) précisant que, dans cette définition, il est

--- a/sources/sections-a1-fr/17-15th-cgpm.adoc
+++ b/sources/sections-a1-fr/17-15th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Valeur recommandée pour la vitesse de la lumière* (<<CR1975-2>> et _Metrologia_, 1975, *11*, 179-180)
+*Valeur recommandée pour la vitesse de la lumière* (<<CR1975-2>> et <<Met_11_4_179,_Metrologia_, 1975, *11*, 179-180>>)
 
 [[cgpm15e1975r2r2]]
 ==== Résolution 2
@@ -33,7 +33,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Temps universel coordonné* (UTC) (<<CR1975-5>> et _Metrologia_, 1975, 11, 180) index-range:temps_utc[(((temps,universel coordonné (UTC))))]
+*Temps universel coordonné* (UTC) (<<CR1975-5>> et <<Met_11_4_179,_Metrologia_, 1975, 11, 180>>) index-range:temps_utc[(((temps,universel coordonné (UTC))))]
 
 [[cgpm15e1975r5r5]]
 ==== Résolution 5
@@ -58,7 +58,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Unités SI pour les rayonnements ionisants (becquerel et gray)* (<<CR1975-8>> et _Metrologia_, 1975, *11*, 180)(((gray (stem:["unitsml(Gy)"]))))(((rayonnements ionisants)))(((becquerel (stem:["unitsml(Bq)"]))))
+*Unités SI pour les rayonnements ionisants (becquerel et gray)* (<<CR1975-8>> et <<Met_11_4_179,_Metrologia_, 1975, *11*, 180>>)(((gray (stem:["unitsml(Gy)"]))))(((rayonnements ionisants)))(((becquerel (stem:["unitsml(Bq)"]))))
 
 NOTE: À sa session de 1976, le Comité international a
 approuvé le rapport de la 5^e^ session du CCU (1976)
@@ -103,7 +103,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Préfixes SI péta et exa* (<<CR1975-10>> et _Metrologia_, 1975, *11*, 180-181)(((préfixes SI)))
+*Préfixes SI péta et exa* (<<CR1975-10>> et <<Met_11_4_179,_Metrologia_, 1975, *11*, 180-181>>)(((préfixes SI)))
 
 NOTE: De nouveaux préfixes furent ajoutés en 1991 par la 19^e^ CGPM (<<cgpm19e1991r4r4,Résolution 4>>).
 

--- a/sources/sections-a1-fr/18-16th-cgpm.adoc
+++ b/sources/sections-a1-fr/18-16th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Unité SI d’intensité lumineuse (candela)* (<<CR1979-3>> et _Metrologia_, 1980, *16*, 56)(((candela (stem:["unitsml(cd)"]))))
+*Unité SI d’intensité lumineuse (candela)* (<<CR1979-3>> et <<Met_16_1_55,_Metrologia_, 1980, *16*, 56>>)(((candela (stem:["unitsml(cd)"]))))
 
 NOTE: La formulation de la définition de la candela(((candela (stem:["unitsml(cd)"])))) a été modifiée par la CGPM à sa 26^e^ réunion en 2018 (<<cgpm26th2018r1r1,Résolution 1>>).
 
@@ -64,7 +64,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Nom spécial pour l’unité SI d’équivalent de dose (sievert)* (<<CR1979-5>> et _Metrologia_, 1980, *16*, 56)(((sievert (stem:["unitsml(Sv)"]))))
+*Nom spécial pour l’unité SI d’équivalent de dose (sievert)* (<<CR1979-5>> et <<Met_16_1_55,_Metrologia_, 1980, *16*, 56>>)(((sievert (stem:["unitsml(Sv)"]))))
 
 NOTE: Le Comité international a décidé en 1984 d’accompagner cette
 Résolution d’une explication, (<<cipm1984r1r1,Recommandation 1>>).
@@ -95,7 +95,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Symboles du litre* (<<CR1979-6>> et _Metrologia_, 1980, *16*, 56-57)
+*Symboles du litre* (<<CR1979-6>> et <<Met_16_1_55,_Metrologia_, 1980, *16*, 56-57>>)
 
 [[cgpm16e1979r6r6]]
 ==== Résolution 6 (((litre (stem:["unitsml(L)"] ou stem:["unitsml(l)"]))))

--- a/sources/sections-a1-fr/19-cipm-1980.adoc
+++ b/sources/sections-a1-fr/19-cipm-1980.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Unités SI supplémentaires (radian et stéradian)* (<<PV48>> et _Metrologia_, 1981, *17*, 72)(((radian (stem:["unitsml(rad)"]))))
+*Unités SI supplémentaires (radian et stéradian)* (<<PV48>> et <<Met_17_2_69,_Metrologia_, 1981, *17*, 72>>)(((radian (stem:["unitsml(rad)"]))))
 
 NOTE: La classe des unités supplémentaires dans le SI
 a été abrogée en 1995 par décision de la 20^e^ CGPM (<<cgpm20e1995r8r8,Résolution 8>>).

--- a/sources/sections-a1-fr/20-17th-cgpm.adoc
+++ b/sources/sections-a1-fr/20-17th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Définition du mètre* (<<CR1983-1>> et _Metrologia_, 1984, *20*, 25)
+*Définition du mètre* (<<CR1983-1>> et <<Met_20_1_25,_Metrologia_, 1984, *20*, 25>>)
 
 NOTE: La formulation de la définition du mètre a été
 modifiée par la CGPM à sa 26^e^ réunion en 2018 (<<cgpm26th2018r1r1,Résolution 1>>).
@@ -65,7 +65,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Sur la mise en pratique de la définition du mètre* (<<CR1983-2>> et _Metrologia_, 1984, *20*, 25-26)
+*Sur la mise en pratique de la définition du mètre* (<<CR1983-2>> et <<Met_20_1_25,_Metrologia_, 1984, *20*, 25-26>>)
 
 NOTE: _Voir_ Recommandation 1 (<<cipm2002r1r1,CI-2002>>) du CIPM relative à la révision de la mise en pratique de la
 définition du mètre.

--- a/sources/sections-a1-fr/21-cipm-1984.adoc
+++ b/sources/sections-a1-fr/21-cipm-1984.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Au sujet du sievert* (<<PV52>> et _Metrologia_, 1985, *21*, 90)(((sievert (stem:["unitsml(Sv)"]))))
+*Au sujet du sievert* (<<PV52>> et <<Met_21_2_89,_Metrologia_, 1985, *21*, 90>>)(((sievert (stem:["unitsml(Sv)"]))))
 
 NOTE: Le CIPM a décidé en 2002 de modifier les
 explications sur la grandeur «{nbsp}équivalent de

--- a/sources/sections-a1-fr/22-18th-cgpm.adoc
+++ b/sources/sections-a1-fr/22-18th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Ajustement prévu des représentations du volt et de l’ohm* (<<CR1987-6>> et _Metrologia_, 1988, *25*, 115)
+*Ajustement prévu des représentations du volt et de l’ohm* (<<CR1987-6>> et <<Met_25_2_113,_Metrologia_, 1988, *25*, 115>>)
 
 [[cgpm18e1987r6r6]]
 ==== Résolution 6

--- a/sources/sections-a1-fr/23-cipm-1988.adoc
+++ b/sources/sections-a1-fr/23-cipm-1988.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Représentation du volt au moyen de l’effet Josephson* (<<PV56_1>> et _Metrologia_, 1989, *26*, 69)
+*Représentation du volt au moyen de l’effet Josephson* (<<PV56_1>> et <<Met_26_1_69,_Metrologia_, 1989, *26*, 69>>)
 
 NOTE: La CGPM à sa 26^e^ réunion en 2018 (<<cgpm26th2018r1r1,Résolution 1>>) a abrogé l’adoption d’une valeur
 conventionnelle de stem:[ii(K)_"J"].
@@ -56,7 +56,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Représentation de l’ohm au moyen de l’effet Hall quantique* (<<PV56_2>> et _Metrologia_, 1989, *26*, 70)
+*Représentation de l’ohm au moyen de l’effet Hall quantique* (<<PV56_2>> et <<Met_26_1_69,_Metrologia_, 1989, *26*, 70>>)
 
 NOTE: Lors de sa 89^e^ session en 2000, le CIPM a approuvé
 la déclaration de la 22^e^ session du CCEM

--- a/sources/sections-a1-fr/24-cipm-1989.adoc
+++ b/sources/sections-a1-fr/24-cipm-1989.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*L’Échelle internationale de température de 1990* (<<PV57_5>> et _Metrologia_, 1990, *27*, 13)index-range:eit-90[(((échelle,internationale de température de 1990 (EIT-90))))]
+*L’Échelle internationale de température de 1990* (<<PV57_5>> et <<Met_27_1_11,_Metrologia_, 1990, *27*, 13>>)index-range:eit-90[(((échelle,internationale de température de 1990 (EIT-90))))]
 
 NOTE: Le kelvin(((kelvin (stem:["unitsml(K)"])))) a été redéfini par
 la CGPM à sa 26^e^ réunion en 2018 (<<cgpm26th2018r1r1,Résolution 1>>).

--- a/sources/sections-a1-fr/25-19th-cgpm.adoc
+++ b/sources/sections-a1-fr/25-19th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Préfixes SI zetta, zepto, yotta et yocto* (<<CR1983-1>> et _Metrologia_, 1992, *29*, 3)
+*Préfixes SI zetta, zepto, yotta et yocto* (<<CR1991-4>> et <<Met_29_1_1,_Metrologia_, 1992, *29*, 3>>)
 
 [[cgpm19e1991r4r4]]
 ==== Résolution 4

--- a/sources/sections-a1-fr/26-20th-cgpm.adoc
+++ b/sources/sections-a1-fr/26-20th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Suppression de la classe des unités supplémentaires dans le SI* (<<CR1995-8>> et _Metrologia_, 1996, *33*, 83) index-range:steradian_sr[(((stéradian (sr))))]
+*Suppression de la classe des unités supplémentaires dans le SI* (<<CR1995-8>> et <<Met_33_1_81,_Metrologia_, 1996, *33*, 83>>) index-range:steradian_sr[(((stéradian (sr))))]
 
 [[cgpm20e1995r8r8]]
 ==== Résolution 8

--- a/sources/sections-a1-fr/27-21st-cgpm.adoc
+++ b/sources/sections-a1-fr/27-21st-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*La définition du ((kilogramme))* (<<CR1999-7>> et _Metrologia_, 2000, *37*, 94)
+*La définition du ((kilogramme))* (<<CR1999-7>> et <<Met_37_1_87,_Metrologia_, 2000, *37*, 94>>)
 
 [[cgpm21e1999r7r7]]
 ==== Résolution 7
@@ -38,7 +38,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Nom spécial donné à l'unité SI mole par seconde, le katal, pour exprimer l'activité catalytique* (<<CR1999-12>> et _Metrologia_, 2000, *37*, 95) index-range:katal_kat[(((katal (stem:["unitsml(kat)"]))))](((mole (stem:["unitsml(mol)"]))))
+*Nom spécial donné à l'unité SI mole par seconde, le katal, pour exprimer l'activité catalytique* (<<CR1999-12>> et <<Met_37_1_87,_Metrologia_, 2000, *37*, 95>>) index-range:katal_kat[(((katal (stem:["unitsml(kat)"]))))](((mole (stem:["unitsml(mol)"]))))
 
 [[cgpm21e1999r12r12]]
 ==== Résolution 12

--- a/sources/sections-a1-fr/29-cipm-2002.adoc
+++ b/sources/sections-a1-fr/29-cipm-2002.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Révision de la mise en pratique de la définition du mètre* (<<PV70_1>> et _Metrologia_, *40*, 103-133)
+*Révision de la mise en pratique de la définition du mètre* (<<PV70_1>> et <<Met_40_2_103,_Metrologia_, *40*, 103-133>>)
 
 [[cipm2002r1r1]]
 ==== Recommandation 1
@@ -62,8 +62,8 @@ aux longueurs l suffisamment courtes pour que les effets prévus par la relativi
 soient négligeables par rapport aux incertitudes de mesure. Si ce n’est pas le cas,
 il convient de se référer au rapport du Groupe de travail du Comité consultatif du temps
 et des fréquences (CCTF) sur l’application de la relativité générale à la métrologie pour
-l’interprétation des mesures (Application of general relativity to metrology, _Metrologia_,
-1997, *34*, 261-290),
+l’interprétation des mesures (Application of general relativity to metrology,
+<<Met_34_3_261,_Metrologia_, 1997, *34*, 261-290>>),
 
 * que le CIPM avait recommandé une liste de radiations à cet effet{nbsp};
 
@@ -111,7 +111,7 @@ simplicité pour encourager leur mise en pratique la plus étendue{nbsp};
 
 * que la liste des radiations recommandées donnée par le CIPM en 1997 (Recommandation 1
 (CI-1997)) soit remplacée par la liste de radiations ci-dessous footnote:[La liste des radiations recommandées, Recommandation 1
-(CI-2002), figure dans les <<PV70_1>> et dans _Metrologia_, 2003, *40*, 104-115.], qui inclut{nbsp};
+(CI-2002), figure dans les <<PV70_1>> et dans <<<<Met_40_2_103,_Metrologia_, 2003, *40*, 104-115>>.], qui inclut{nbsp};
 
 ** des valeurs mises à jour de la fréquence des atomes de calcium et d’hydrogène refroidis
 et de l’ion piégé de strontium,

--- a/sources/sections-a1-fr/30-cipm-2003.adoc
+++ b/sources/sections-a1-fr/30-cipm-2003.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Révision de la liste des radiations recommandées pour la mise en pratique de la définition du mètre* (<<PV71_1>> et _Metrologia_, 2004, *41*, 99-100) (((mètre (stem:["unitsml(m)"]))))
+*Révision de la liste des radiations recommandées pour la mise en pratique de la définition du mètre* (<<PV71_1>> et <<Met_41_1_99,_Metrologia_, 2004, *41*, 99-100>>) (((mètre (stem:["unitsml(m)"]))))
 
 [[cipm2003r1r1]]
 ==== Recommandation 1

--- a/sources/sections-a1-fr/31-22nd-cgpm.adoc
+++ b/sources/sections-a1-fr/31-22nd-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Symbole du séparateur décimal* (<<CR2003-10>> et _Metrologia_, 2004, *41*, 104)
+*Symbole du séparateur décimal* (<<CR2003-10>> et <<Met_41_1_99,_Metrologia_, 2004, *41*, 104>>)
 
 [[cgpm22e2003r10r10]]
 ==== Résolution 10

--- a/sources/sections-a1-fr/32-cipm-2005.adoc
+++ b/sources/sections-a1-fr/32-cipm-2005.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Clarification de la définition du kelvin, unité de température thermo-dynamique* (<<PV73_2>> et _Metrologia_, 2006, *43*, 177-178)(((kelvin (stem:["unitsml(K)"]))))
+*Clarification de la définition du kelvin, unité de température thermo-dynamique* (<<PV73_2>> et <<Met_43_1_175,_Metrologia_, 2006, *43*, 177-178>>)(((kelvin (stem:["unitsml(K)"]))))
 
 NOTE: Le kelvin a été redéfini par la CGPM à sa 26^e^ réunion en 2018 (<<cgpm26th2018r1r1,Résolution 1>>).
 
@@ -61,7 +61,7 @@ ____
 === {blank}
 
 [.variant-title,type=quoted]
-*Révision de la liste des radiations recommandées pour la mise en pratique de la définition du mètre* (<<PV73_3>> et _Metrologia_, 2006, *43*, 178)
+*Révision de la liste des radiations recommandées pour la mise en pratique de la définition du mètre* (<<PV73_3>> et <<Met_43_1_175,_Metrologia_, 2006, *43*, 178>>)
 
 [[cipm2005r3r3]]
 ==== Recommandation 3

--- a/sources/sections-a1-fr/33-cipm-2006.adoc
+++ b/sources/sections-a1-fr/33-cipm-2006.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Au sujet des représentations secondaires de la seconde* (<<PV74>> et _Metrologia_, 2007, *44*, 97) (((seconde)))
+*Au sujet des représentations secondaires de la seconde* (<<PV74>> et <<Met_44_1_97,_Metrologia_, 2007, *44*, 97>>) (((seconde)))
 
 [[cipm2006r1r1]]
 ==== Recommandation 1

--- a/sources/sections-a1-fr/39-25th-cgpm.adoc
+++ b/sources/sections-a1-fr/39-25th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Sur la révision à venir du Système international d’unités, le SI* (<<CR2014-1>> et _Metrologia_, 2015, *52*, 155)
+*Sur la révision à venir du Système international d’unités, le SI* (<<CR2014-1>> et <<Met_52_1_155,_Metrologia_, 2015, *52*, 155>>)
 
 NOTE: La CGPM à sa 26^e^ réunion (2018) a approuvé la révision du SI (<<cgpm26th2018r1r1,Résolution 1>>).
 

--- a/sources/sections-a1-fr/42-26th-cgpm.adoc
+++ b/sources/sections-a1-fr/42-26th-cgpm.adoc
@@ -7,7 +7,7 @@
 === {blank}
 
 [.variant-title,type=quoted]
-*Sur la révision du Système international d’unités (SI)* (CR, sous presse et _Metrologia_, 2019, *56*, 022001)
+*Sur la révision du Système international d’unités (SI)* (CR, sous presse et <<Met_56_2_022001,_Metrologia_, 2019, *56*, 022001>>)
 
 [[cgpm26th2018r1r1]]
 ==== Résolution 1

--- a/sources/sections-en/99-bibliography.adoc
+++ b/sources/sections-en/99-bibliography.adoc
@@ -200,3 +200,51 @@
 
 // CIPM Meeting (1879)
 * [[[PV41_h,CIPM Meeting 4]]]
+
+
+// Metrologia references
+
+* [[[Met_4_1_41,BIPM Metrologia 4 1 41]]]
+
+* [[[Met_6_2_65,BIPM Metrologia 6 2 65]]]
+
+* [[[Met_7_1_43,BIPM Metrologia 7 1 43]]]
+
+* [[[Met_8_1_32,BIPM Metrologia 8 1 32]]]
+
+* [[[Met_11_4_179,BIPM Metrologia 11 4 179]]]
+
+* [[[Met_16_1_55,BIPM Metrologia 16 1 55]]]
+
+* [[[Met_17_2_69,BIPM Metrologia 17 2 69]]]
+
+* [[[Met_20_1_25,BIPM Metrologia 20 1 25]]]
+
+* [[[Met_21_2_89,BIPM Metrologia 21 2 89]]]
+
+* [[[Met_25_2_113,BIPM Metrologia 25 2 113]]]
+
+* [[[Met_26_1_69,BIPM Metrologia 26 1 69]]]
+
+* [[[Met_27_1_11,BIPM Metrologia 27 1 11]]]
+
+* [[[Met_29_1_1,BIPM Metrologia 29 1 1]]]
+
+* [[[Met_33_1_81,BIPM Metrologia 33 1 81]]]
+
+* [[[Met_34_3_261,BIPM Metrologia 34 3 261]]]
+
+* [[[Met_37_1_87,BIPM Metrologia 37 1 87]]]
+
+* [[[Met_40_2_103,BIPM Metrologia 40 2 103]]]
+
+* [[[Met_41_1_99,BIPM Metrologia 41 1 99]]]
+
+* [[[Met_43_1_175,BIPM Metrologia 43 1 175]]]
+
+* [[[Met_44_1_97,BIPM Metrologia 44 1 97]]]
+
+* [[[Met_52_1_155,BIPM Metrologia 52 1 155]]]
+
+* [[[Met_56_2_022001,BIPM Metrologia 56 2 022001]]]
+

--- a/sources/sections-fr/99-bibliography.adoc
+++ b/sources/sections-fr/99-bibliography.adoc
@@ -198,3 +198,50 @@
 
 // CIPM Meeting (1879)
 * [[[PV41_h,CIPM Réunion 4]]]
+
+
+// Metrologia references
+
+* [[[Met_4_1_41,BIPM Metrologia 4 1 41]]]
+
+* [[[Met_6_2_65,BIPM Metrologia 6 2 65]]]
+
+* [[[Met_7_1_43,BIPM Metrologia 7 1 43]]]
+
+* [[[Met_8_1_32,BIPM Metrologia 8 1 32]]]
+
+* [[[Met_11_4_179,BIPM Metrologia 11 4 179]]]
+
+* [[[Met_16_1_55,BIPM Metrologia 16 1 55]]]
+
+* [[[Met_17_2_69,BIPM Metrologia 17 2 69]]]
+
+* [[[Met_20_1_25,BIPM Metrologia 20 1 25]]]
+
+* [[[Met_21_2_89,BIPM Metrologia 21 2 89]]]
+
+* [[[Met_25_2_113,BIPM Metrologia 25 2 113]]]
+
+* [[[Met_26_1_69,BIPM Metrologia 26 1 69]]]
+
+* [[[Met_27_1_11,BIPM Metrologia 27 1 11]]]
+
+* [[[Met_29_1_1,BIPM Metrologia 29 1 1]]]
+
+* [[[Met_33_1_81,BIPM Metrologia 33 1 81]]]
+
+* [[[Met_34_3_261,BIPM Metrologia 34 3 261]]]
+
+* [[[Met_37_1_87,BIPM Metrologia 37 1 87]]]
+
+* [[[Met_40_2_103,BIPM Metrologia 40 2 103]]]
+
+* [[[Met_41_1_99,BIPM Metrologia 41 1 99]]]
+
+* [[[Met_43_1_175,BIPM Metrologia 43 1 175]]]
+
+* [[[Met_44_1_97,BIPM Metrologia 44 1 97]]]
+
+* [[[Met_52_1_155,BIPM Metrologia 52 1 155]]]
+
+* [[[Met_56_2_022001,BIPM Metrologia 56 2 022001]]]


### PR DESCRIPTION
This PR inserts Metrologia references to the Brochure.

Note:
There are BIPM webpages containing Metrologia wrong hyperlinks.
For example, in this page https://www.bipm.org/en/committees/cg/cgpm/13-1967/resolution-1,
the Metrologia reference should point to "Metrologia 4 1 41" (volume=4, issue=1, page=41)
but the hyperlink leads to "Metrologia 41 1 41" (volume=41, issue=1, page=41).
Maybe we should report this error?