### PR TITLE
Add missing :docnumber: attributes

### DIFF
--- a/sources/si-brochure-concise-en.adoc
+++ b/sources/si-brochure-concise-en.adoc
@@ -1,4 +1,5 @@
 = A concise summary of the International System of Units, SI
+:docnumber: Brochure
 :edition: 9
 :draft: v3.01
 :copyright-year: 2019

--- a/sources/si-brochure-concise-en.adoc
+++ b/sources/si-brochure-concise-en.adoc
@@ -1,5 +1,5 @@
 = A concise summary of the International System of Units, SI
-:docnumber: Brochure
+:docnumber: Brochure Concise
 :edition: 9
 :draft: v3.01
 :copyright-year: 2019

--- a/sources/si-brochure-concise-fr.adoc
+++ b/sources/si-brochure-concise-fr.adoc
@@ -1,4 +1,5 @@
 = A concise summary of the International System of Units, SI
+:docnumber: Brochure
 :edition: 9
 :draft: v3.01
 :copyright-year: 2019

--- a/sources/si-brochure-concise-fr.adoc
+++ b/sources/si-brochure-concise-fr.adoc
@@ -1,5 +1,5 @@
 = A concise summary of the International System of Units, SI
-:docnumber: Brochure
+:docnumber: Brochure Concise
 :edition: 9
 :draft: v3.01
 :copyright-year: 2019

--- a/sources/si-brochure-faq-en.adoc
+++ b/sources/si-brochure-faq-en.adoc
@@ -1,5 +1,5 @@
 = SI Brochure FAQ
-:docnumber: Brochure
+:docnumber: Brochure FAQ
 :edition: 9
 :copyright-year: 2019
 :revdate: 2019-05-20

--- a/sources/si-brochure-faq-en.adoc
+++ b/sources/si-brochure-faq-en.adoc
@@ -1,4 +1,5 @@
 = SI Brochure FAQ
+:docnumber: Brochure
 :edition: 9
 :copyright-year: 2019
 :revdate: 2019-05-20

--- a/sources/si-brochure-faq-fr.adoc
+++ b/sources/si-brochure-faq-fr.adoc
@@ -1,5 +1,5 @@
 = SI Brochure FAQ
-:docnumber: Brochure
+:docnumber: Brochure FAQ
 :edition: 9
 :copyright-year: 2019
 :revdate: 2019-05-20

--- a/sources/si-brochure-faq-fr.adoc
+++ b/sources/si-brochure-faq-fr.adoc
@@ -1,4 +1,5 @@
 = SI Brochure FAQ
+:docnumber: Brochure
 :edition: 9
 :copyright-year: 2019
 :revdate: 2019-05-20


### PR DESCRIPTION
Fixes https://github.com/metanorma/bipm-si-brochure/issues/285

I've used `:docnumber: Brochure` as in the other parts of the Brochure.