### PR TITLE
Route release.yml through metanorma/support wrapper

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,6 +26,6 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        uses: "pascalgn/automerge-action@v0.15.6"
+        uses: pascalgn/automerge-action@v0.16
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  pull-requests: write
+  contents: write
   pages: write
   id-token: write
 
@@ -24,29 +25,23 @@ jobs:
       image: metanorma/metanorma:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
-      - name: Bundler install
-        uses: metanorma/ci/docker-gem-install@main
-
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@v1
+        id: build-and-publish
+        uses: actions-mn/build-and-publish@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          destination: gh-pages
           agree-to-terms: true
-          use-bundler: true
+          destination: artifact
 
   deploy:
-    if: ${{ github.ref_name == github.event.repository.default_branch }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions-mn/deploy-pages@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -29,7 +29,7 @@ jobs:
         uses: actions-mn/setup@main
 
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@v1
+        uses: actions-mn/build-and-publish@main
         with:
           agree-to-terms: true
           destination: artifact


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/292
Full plan: https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md

Routes this repo's `release.yml` through the new `metanorma/support` wrapper, bringing it into alignment with the `<org>/support` pattern already used by `relaton/support`, `fontist/support`, and `lutaml/support`. The `pat_token` reference is dropped (the wrapper does not forward it, matching the convention used by the other org-level support wrappers).

Generated by the cimas-sync wave; canary-verified end-to-end on `metanorma-taste` 1.0.8 (published 2026-06-16 12:54 UTC via the new wrapper path).

🤖
