### PR TITLE
fix(guide-ccem): quoted subscript labels for J-90/K-90 to fix crawler MathML parse

### DIFF
--- a/sources/guide-ccem-ampere-realization/2018/document-en.adoc
+++ b/sources/guide-ccem-ampere-realization/2018/document-en.adoc
@@ -81,10 +81,10 @@ In the electrical community, these changes to the SI primarily involve the fixin
 Planck constant, stem:[h], and the elementary charge, stem:[e]. Fortunately, this concept of using
 values for stem:[h] and stem:[e]
 has been in use by the electrical community since 1990 with the adoption of the conventional values
-of stem:[ii(K)_{J-90} ~= 2e//h] and stem:[ii(R)_{K-90} ~= h//e^2]. However, the new values of stem:[h]
+of stem:[ii(K)_("J-90") ~= 2e//h] and stem:[ii(R)_("K-90") ~= h//e^2]. However, the new values of stem:[h]
 and stem:[e] are slightly different from those
-used to set stem:[ii(K)_{J-90}] and stem:[ii(R)_{K-90}]. The elimination of the '`conventional`'
-units, represented by stem:[ii(K)_{J-90}] and stem:[ii(R)_{K-90}], will mean that the disseminated
+used to set stem:[ii(K)_("J-90")] and stem:[ii(R)_("K-90")]. The elimination of the '`conventional`'
+units, represented by stem:[ii(K)_("J-90")] and stem:[ii(R)_("K-90")], will mean that the disseminated
 electrical units will become fully coherent with the SI. However, this
 will result in a small discontinuous change on the day of implementation of the '`Revised SI`' but,
 from then on, no further changes will be necessary.
@@ -112,7 +112,7 @@ Particular focus should be made on the highest accuracy (lowest uncertainty) com
 for this is given in the next section).
 
 Thirdly, review your quality management documents to identify references to the conventional
-values stem:[ii(K)_{J-90}] and stem:[ii(R)_{K-90}], for example in calibration procedures and
+values stem:[ii(K)_("J-90")] and stem:[ii(R)_("K-90")], for example in calibration procedures and
 measurement software. These
 references need to be updated.
 


### PR DESCRIPTION
## Problem

The `relaton-data-bipm` **v2 crawler** is failing in CI ([run 27096686793](https://github.com/relaton/relaton-data-bipm/actions/runs/27096686793/job/79970005389)) during the `build_rxl_only.rb` Metanorma build:

```
[plurimath] Error: Failed to parse the following formula with type `mathml`.
Asciimath original: ii(K)_{J-90} ~= 2e//h
...
Command 'bundle exec ruby build_rxl_only.rb' failed with exit code 1
```

## Root cause

`sources/guide-ccem-ampere-realization/2018/document-en.adoc` is the **only** document in the repo that writes the Josephson/von Klitzing conventional-value constants with the **curly-brace subscript** form:

```asciidoc
stem:[ii(K)_{J-90} ~= 2e//h] and stem:[ii(R)_{K-90} ~= h//e^2]
```

`{J-90}` is parsed as a group `J − 90`, so Standoc emits a subscript of
`<mrow><mi>J</mi><mo>−</mo><mn>90</mn></mrow>`. When the presentation pipeline
re-parses that cleaned MathML through plurimath 0.10.5 / mml 2.3.7, the parse
throws and aborts the build. It is the only document in the run's error list.

## Fix

`J-90` / `K-90` are **1990-convention labels**, not subtractions, so the quoted
form `ii(K)_("J-90")` is semantically correct *and* matches the notation already
used everywhere else in the SI Brochure (e.g.
`sections-a1-en/23-cipm-1988.adoc`, `42-26th-cgpm.adoc`), which build cleanly.
This normalizes all four occurrences in the affected file to the quoted form.

No other files use the curly-brace form in a full formula, so this is the
complete fix for the crawler failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)